### PR TITLE
[#7] RFC-compliant Sieve string.

### DIFF
--- a/src/main/java/com/fluffypeople/managesieve/ManageSieveClient.java
+++ b/src/main/java/com/fluffypeople/managesieve/ManageSieveClient.java
@@ -672,7 +672,7 @@ public class ManageSieveClient {
 
         result.append("{");
         result.append(Integer.toString(raw.getBytes(UTF8).length));
-        result.append("}");
+        result.append("+}");
         result.append(CRLF);
         result.append(raw);
 


### PR DESCRIPTION
When sending data to the server, use the 'literal-c2s' form from RFC 5804.