### PR TITLE
Make charset configurable (via property)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.fluffypeople</groupId>
     <artifactId>managesievej</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.1-KIJ</version>
     <packaging>jar</packaging>
     <name>ManageSieveJ</name>
     <url>https://github.com/Moosemorals/ManageSieveJ</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.fluffypeople</groupId>
     <artifactId>managesievej</artifactId>
-    <version>0.3.1-KIJ</version>
+    <version>0.3.1</version>
     <packaging>jar</packaging>
     <name>ManageSieveJ</name>
     <url>https://github.com/Moosemorals/ManageSieveJ</url>

--- a/src/main/java/com/fluffypeople/managesieve/xml/XML.java
+++ b/src/main/java/com/fluffypeople/managesieve/xml/XML.java
@@ -127,7 +127,7 @@ public class XML {
      * Start an XML element, including attributes if any
      *
      * @param tag String name of the element
-     * @param attrib Map<String, String> holding key, value attribute pairs.
+     * @param attrib Map&lt;String, String&gt; holding key, value attribute pairs.
      * Ignored if null.
      * @return this XML document
      */
@@ -236,7 +236,7 @@ public class XML {
      *
      * @param tag String giving the name of the element
      * @param text String contents of the element.
-     * @param attrib Map<String, String> holding key, value attribute pairs.
+     * @param attrib Map&lt;String, String&gt; holding key, value attribute pairs.
      * Ignored if null.
      * @return this XML document
      */
@@ -266,7 +266,7 @@ public class XML {
     /**
      * Add an empty element to the tree
      *
-     * @param tag String givng the name of the element
+     * @param tag String giving the name of the element
      * @return this XML document
      */
     public XML add(String tag) {

--- a/src/test/java/com/fluffypeople/managesieve/ManageSieveClientTest.java
+++ b/src/test/java/com/fluffypeople/managesieve/ManageSieveClientTest.java
@@ -24,7 +24,7 @@ public class ManageSieveClientTest {
                 {"\u0601\u0602\u0603\u0604\u0605\u061C\u06DD\u070F\u180E\u200B\u200C\u200D\u200E\u200F\u202A\u202B\u202C\u202D\u202E\u2060\u2061\u2062\u2063\u2064\u2066\u2067\u2068\u2069\u206A\u206B\u206C\u206D\u206E\u206F\uFEFF\uFFF9\uFFFA\uFFFB\uD804\uDCBD"}, // Unicode additional control characters
                 {"ÅÍÎÏ˝ÓÔ\uF8FFÒÚÆ☃¡™£¢∞§¶•ªº–≠"}, // More funky unicode
                 {"田中さんにあげて下さい"}, // Two byte chars
-                {"表ポあA鷗ŒéＢ逍Üßªąñ丂㐀\uD840\uDC00"}, // Extream unicode
+                {"表ポあA鷗ŒéＢ逍Üßªąñ丂㐀\uD840\uDC00"}, // Extreme unicode
                 {"❤️ \uD83D\uDC94 \uD83D\uDC8C \uD83D\uDC95 \uD83D\uDC9E \uD83D\uDC93 \uD83D\uDC97 \uD83D\uDC96 \uD83D\uDC98 \uD83D\uDC9D \uD83D\uDC9F \uD83D\uDC9C \uD83D\uDC9B \uD83D\uDC9A \uD83D\uDC99"}, // Emoji
                 {"בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ"}, // Right to left
 


### PR DESCRIPTION
The charset was hardcoded to UTF-8 which is probably correct in most cases, but we needed to change it. To make that possible a property has been added which allows to set an encoding. "sieve.charset" e.g.

`java -jar <whatever> -Dsieve.charset=ISO_8859_1`